### PR TITLE
fix: Run PlannedReparentShard to remedy unhealthy tablets

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -245,6 +245,23 @@ services:
     - "3306"
     volumes:
     - .:/script
+  vtctlclient101:
+    command:
+      - sh
+      - -c
+      - /script/setup_shards.sh
+    depends_on:
+      - vttablet101
+      - vttablet102
+    environment:
+      - KEYSPACE=test_keyspace
+      - SHARD=-80
+      - TARGETTAB=test-0000000101
+      - SLEEPTIME=10
+      - VTCTLD_SERVER=
+    image: vitess/lite:${VITESS_TAG:-latest}
+    volumes:
+      - .:/script
   vttablet201:
     command:
     - sh
@@ -319,6 +336,23 @@ services:
     - "3306"
     volumes:
     - .:/script
+  vtctlclient201:
+    command:
+      - sh
+      - -c
+      - /script/setup_shards.sh
+    depends_on:
+      - vttablet201
+      - vttablet202
+    environment:
+      - KEYSPACE=test_keyspace
+      - SHARD=80-
+      - TARGETTAB=test-0000000201
+      - SLEEPTIME=10
+      - VTCTLD_SERVER=
+    image: vitess/lite:${VITESS_TAG:-latest}
+    volumes:
+      - .:/script
   vttablet301:
     command:
     - sh
@@ -393,6 +427,23 @@ services:
     - "3306"
     volumes:
     - .:/script
+  vtctlclient301:
+    command:
+      - sh
+      - -c
+      - /script/setup_shards.sh
+    depends_on:
+      - vttablet301
+      - vttablet302
+    environment:
+      - KEYSPACE=lookup_keyspace
+      - SHARD=-
+      - TARGETTAB=test-0000000301
+      - SLEEPTIME=10
+      - VTCTLD_SERVER=
+    image: vitess/lite:${VITESS_TAG:-latest}
+    volumes:
+      - .:/script
   vtwork:
     command:
     - sh

--- a/compose/setup_shards.sh
+++ b/compose/setup_shards.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -ex
+
+keyspace=${KEYSPACE:-'test_keyspace'}
+shard=${SHARD:-'0'}
+targettab=${TARGETTAB:-"${CELL}-0000000101"}
+sleeptime=${SLEEPTIME:-'10'}
+
+export PATH=/vt/bin:$PATH
+
+VTCTLD_SERVER=${VTCTLD_SERVER:-'vtctld:15999'}
+
+# To avoid the timing error like
+# `remote error: rpc error: code = Unknown desc = node doesn't exist: vitess/global/keyspaces/test_keyspace/shards/-80/`
+sleep $sleeptime
+
+vtctlclient -server $VTCTLD_SERVER PlannedReparentShard --keyspace_shard="$keyspace/$shard" --new_primary=$targettab


### PR DESCRIPTION
# Version

```
(base) ❯ docker image inspect vitess/lite:latest
[
    {
        "Id": "sha256:3842523b94cb535f9b1eee0a606061a52bb0fb981f625d942df8fa90b6694e03",
        "RepoTags": [
            "vitess/lite:latest"
        ],
        "RepoDigests": [
            "vitess/lite@sha256:9d4c869d788d8db820cbb701e0ac9064bd188d85b4c5fc97862488c759c0bddb"
        ],
        "Parent": "",
        "Comment": "buildkit.dockerfile.v0",
        "Created": "2022-06-16T08:17:50.667829895Z",
```

```
vitess@7afca93789f9:/vt/bin$ ./vtgate --version
ERROR: logging before flag.Parse: E0624 05:54:52.603919    1566 syslogger.go:149] can't connect to syslog
Version: 15.0.0-SNAPSHOT (Git revision e74f1f1f821fa0be42effcd921e206f202926ad0 branch 'main') built on Thu Jun 16 08:10:26 UTC 2022 by vitess@buildkitsandbox using go1.18.3 linux/amd64
```

- ref. https://github.com/vitessio/vitess/commit/e74f1f1f821fa0be42effcd921e206f202926ad0

# Problem

After running `docker-compose up -d,` the setup got stuck due to the unhealthy vttablets.

```
(base) examples/compose❯ docker-compose ps
           Name                         Command                   State                                                       Ports
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
compose_consul1_1            docker-entrypoint.sh agent ...   Up               8300/tcp, 8301/tcp, 8301/udp, 8302/tcp, 8302/udp, 0.0.0.0:8400->8400/tcp,:::8400->8400/tcp,
                                                                               0.0.0.0:8500->8500/tcp,:::8500->8500/tcp, 0.0.0.0:8600->8600/tcp,:::8600->8600/tcp, 8600/udp
compose_consul2_1            docker-entrypoint.sh agent ...   Up               8300/tcp, 8301/tcp, 8301/udp, 8302/tcp, 8302/udp, 8400/tcp, 8500/tcp, 8600/tcp, 8600/udp
compose_consul3_1            docker-entrypoint.sh agent ...   Up               8300/tcp, 8301/tcp, 8301/udp, 8302/tcp, 8302/udp, 8400/tcp, 8500/tcp, 8600/tcp, 8600/udp
compose_external_db_host_1   docker-entrypoint.sh --ser ...   Up (healthy)     0.0.0.0:58068->3306/tcp, 33060/tcp
compose_vreplication_1       sh -c [ $EXTERNAL_DB -eq 1 ...   Exit 0
compose_vtctld_1             sh -c  /vt/bin/vtctld -top ...   Up               0.0.0.0:58132->15999/tcp, 0.0.0.0:15000->8080/tcp,:::15000->8080/tcp
compose_vtgate_1             sh -c /script/run-forever. ...   Up               0.0.0.0:15306->15306/tcp,:::15306->15306/tcp, 0.0.0.0:58149->15999/tcp,
                                                                               0.0.0.0:15099->8080/tcp,:::15099->8080/tcp
compose_vtorc_1              sh -c /script/vtorc-up.sh        Up               0.0.0.0:13000->3000/tcp,:::13000->3000/tcp
compose_vttablet101_1        sh -c /script/vttablet-up. ...   Up (unhealthy)   0.0.0.0:58147->15999/tcp, 0.0.0.0:58148->3306/tcp, 0.0.0.0:15101->8080/tcp,:::15101->8080/tcp
compose_vttablet102_1        sh -c /script/vttablet-up. ...   Up (unhealthy)   0.0.0.0:58145->15999/tcp, 0.0.0.0:58146->3306/tcp, 0.0.0.0:15102->8080/tcp,:::15102->8080/tcp
compose_vttablet201_1        sh -c /script/vttablet-up. ...   Up (unhealthy)   0.0.0.0:58141->15999/tcp, 0.0.0.0:58142->3306/tcp, 0.0.0.0:15201->8080/tcp,:::15201->8080/tcp
compose_vttablet202_1        sh -c /script/vttablet-up. ...   Up (unhealthy)   0.0.0.0:58133->15999/tcp, 0.0.0.0:58134->3306/tcp, 0.0.0.0:15202->8080/tcp,:::15202->8080/tcp
compose_vttablet301_1        sh -c /script/vttablet-up. ...   Up (unhealthy)   0.0.0.0:58144->15999/tcp, 0.0.0.0:58143->3306/tcp, 0.0.0.0:15301->8080/tcp,:::15301->8080/tcp
compose_vttablet302_1        sh -c /script/vttablet-up. ...   Up (unhealthy)   0.0.0.0:58138->15999/tcp, 0.0.0.0:58139->3306/tcp, 0.0.0.0:15302->8080/tcp,:::15302->8080/tcp
compose_vtwork_1             sh -c /vt/bin/vtworker -to ...   Up               0.0.0.0:58136->15999/tcp, 0.0.0.0:58137->8080/tcp
```

![image](https://user-images.githubusercontent.com/1223268/175469361-cee2fa2e-b692-41d4-bc77-52e9f0f825ab.png)

# Solution

This unhealthy status is described at the document[1] like `The vttablet will be unhealthy because the database for the keyspace has not been created. Visiting the /debug/status page on its port should show the following information:`.

- [1] https://vitess.io/docs/13.0/user-guides/configuration-basic/vttablet-mysql/#key-configuration-notes

You need to perform the PlannedReparentShard command to create the database for the keyspace.
`The PlannedReparentShard command should be used to initialize the shard by electing a new primary and setting up replication for the replicas. Additionally, a database is created to store the data for the keyspace-shard.`

- [2] https://vitess.io/docs/13.0/user-guides/configuration-basic/initialize-shard-primary/

Added one-off containers including vtctlclient101, vtctlclient201, and vtctlclient301 are supposed to 
run this command.