### PR TITLE
fix: vtgate should write a vindex record then an actual record

### DIFF
--- a/compose/lookup_keyspace_vschema.json
+++ b/compose/lookup_keyspace_vschema.json
@@ -4,16 +4,16 @@
 		"messages_message_lookup": {
 			"column_vindexes": [
 				{
-					"column": "id",
-					"name": "hash"
+					"column": "message",
+					"name": "unicode_loose_md5"
 				}
 			]
 		},
 		"tokens_token_lookup": {
 			"column_vindexes": [
 				{
-					"column": "id",
-					"name": "hash"
+					"column": "token",
+					"name": "unicode_loose_md5"
 				}
 			]
 		}
@@ -21,6 +21,9 @@
 	"vindexes": {
 		"hash": {
 			"type": "hash"
+		},
+		"unicode_loose_md5": {
+			"type": "unicode_loose_md5"
 		}
 	}
 }

--- a/compose/tables/lookup_keyspace_schema_file.sql
+++ b/compose/tables/lookup_keyspace_schema_file.sql
@@ -1,16 +1,13 @@
 CREATE TABLE tokens_token_lookup (
-  id BIGINT NOT NULL AUTO_INCREMENT,
   page BIGINT UNSIGNED,
   token VARCHAR(255) DEFAULT NULL,
-  PRIMARY KEY (id),
+  PRIMARY KEY (page),
   UNIQUE KEY idx_token_page (`token`, `page`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE messages_message_lookup (
-  id BIGINT NOT NULL AUTO_INCREMENT,
-  page BIGINT UNSIGNED,
   message VARCHAR(1000),
-  PRIMARY KEY (id),
-  UNIQUE KEY idx_message_page (`message`, `page`)
+  page BIGINT UNSIGNED,
+  PRIMARY KEY (message, page)
 ) ENGINE=InnoDB;
 

--- a/compose/test_keyspace_vschema.json
+++ b/compose/test_keyspace_vschema.json
@@ -31,7 +31,7 @@
 			"type": "hash"
 		},
 		"messages_message_lookup": {
-			"type": "lookup_hash",
+			"type": "lookup_hash_unique",
 			"params": {
 				"table": "lookup_keyspace.messages_message_lookup",
 				"from": "message",
@@ -41,7 +41,7 @@
 			"owner": "messages"
 		},
 		"tokens_token_lookup": {
-			"type": "lookup_hash",
+			"type": "lookup_hash_unique",
 			"params": {
 				"table": "lookup_keyspace.tokens_token_lookup",
 				"from": "token",


### PR DESCRIPTION
# Version

```
(base) ❯ docker image inspect vitess/lite:latest
[
    {
        "Id": "sha256:3842523b94cb535f9b1eee0a606061a52bb0fb981f625d942df8fa90b6694e03",
        "RepoTags": [
            "vitess/lite:latest"
        ],
        "RepoDigests": [
            "vitess/lite@sha256:9d4c869d788d8db820cbb701e0ac9064bd188d85b4c5fc97862488c759c0bddb"
        ],
        "Parent": "",
        "Comment": "buildkit.dockerfile.v0",
        "Created": "2022-06-16T08:17:50.667829895Z",
```

```
vitess@7afca93789f9:/vt/bin$ ./vtgate --version
ERROR: logging before flag.Parse: E0624 05:54:52.603919    1566 syslogger.go:149] can't connect to syslog
Version: 15.0.0-SNAPSHOT (Git revision e74f1f1f821fa0be42effcd921e206f202926ad0 branch 'main') built on Thu Jun 16 08:10:26 UTC 2022 by vitess@buildkitsandbox using go1.18.3 linux/amd64
```

- ref. https://github.com/vitessio/vitess/commit/e74f1f1f821fa0be42effcd921e206f202926ad0

# Problem

When you insert a record to messages, you also expect that the vtgate inserts a lookup record in the vindex table.

```SQL
mysql> insert into messages(page,time_created_ns,message) values(1,10,"alice");
Query OK, 1 row affected (0.03 sec)
```

If you enable the vtgate's querylog, you can see the following seemingly correct logs.

> VindexCreate    172.26.0.1:55044        root    'userData1'     'root'  2022-06-22 12:21:42.389299      2022-06-22 12:21:42.390819      0.001520        0.001314        0.000144 0.000009 INSERT  "insert into lookup_keyspace.messages_message_lookup(message, page) values (:message_0, :page_0) on duplicate key update message = values(message), page = values(page)"  map[message_0:type:VARCHAR value:"emma" page_0:type:UINT64 value:"5"]   0       0       ""      "lookup_keyspace"       "messages_message_lookup"       "PRIMARY"

> Execute 172.26.0.1:55044        root    'userData1'     'root'  2022-06-22 12:21:42.375140      2022-06-22 12:21:42.425217      0.050070        0.007611        0.042413        0.000009  INSERT  "insert into messages(page, time_created_ns, message) values (:vtg1, :vtg2, :vtg3)"     map[vtg1:type:INT64 value:"5" vtg2:type:INT64 value:"10" vtg3:type:VARCHAR value:"emma"]  1       1       ""      "test_keyspace" "messages"      "PRIMARY"

But, the corresponding lookup table has no record.

```SQL
mysql> select * from lookup_keyspace.messages_message_lookup;
Empty set (0.00 sec)
```

# Cause

The above log shows that vtgate tried to run `insert into lookup_keyspace.messages_message_lookup(message, page) values (:message_0, :page_0) on duplicate key update message = values(message), page = values(page).`

This insert command fails due to the missing id (primary key/auto_increment) in the first place.

```SQL
mysql> insert into messages_message_lookup(page, message) values(5000, "alfeibkabke");
ERROR 1105 (HY000): could not map [NULL] to a keyspace id
```

# Solution

Get rid of auto_incremented id from the lookup tables.